### PR TITLE
docs: replace legacy observeAgentPeers with current field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Recommended starting configuration:
 - `syncIssueDocuments: true`
 - `enablePromptContext: false`
 - `enablePeerChat: true`
-- `observeAgentPeers: false`
+- `observeMe: true`
+- `observeOthers: true`
 
 ## Notes
 


### PR DESCRIPTION
The README's recommended starting configuration references `observeAgentPeers`, which is a legacy fallback field in `config.ts` (line 22). The current config schema, `DEFAULT_CONFIG`, and the Honcho docs PR (#502) all use `observeMe` and `observeOthers`.

This one-line fix aligns the README with the shipped field names.

**Change:**
```diff
-- `observeAgentPeers: false`
+- `observeMe: true`
+- `observeOthers: true`
```

Ref: plastic-labs/honcho#502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the recommended starting configuration with new settings for enhanced control over observation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->